### PR TITLE
Updated Slack.java

### DIFF
--- a/src/main/java/us/circuitsoft/slack/Slack.java
+++ b/src/main/java/us/circuitsoft/slack/Slack.java
@@ -24,8 +24,8 @@ public class Slack extends JavaPlugin implements Listener {
         getLogger().info("Slack has been enabled.");
         getServer().getPluginManager().registerEvents(this, this);
         this.saveDefaultConfig();
-        setWebhook = getConfig().getString("webhook").equals("https://hooks.slack.com/services/");
-        if (getConfig().getString("webhook").equals("https://hooks.slack.com/services/")) {
+        setWebhook = !getConfig().getString("webhook").equals("https://hooks.slack.com/services/");
+        if (!setWebhook) {
             getLogger().severe("You have not set your webhook URL in the config!");
         }
     }
@@ -65,7 +65,7 @@ public class Slack extends JavaPlugin implements Listener {
     }
 
     public void post(String b) {
-        if (setWebhook) {
+        if (!setWebhook) {
             getLogger().severe("You have not set your webhook URL in the config!");
         } else {
             try {


### PR DESCRIPTION
Removed the unnecessary `getConfig().getString("webhook").equals("https://hooks.slack.com/services/")`
I also made it so if webhook is set it will be true and if it is not it will be false, just to be neater.
