### PR TITLE
Matching commands precisely.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>us.circuitsoft.slack</groupId>
     <artifactId>Slack</artifactId>
-    <version>1.4.4</version>
+    <version>1.5.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/circuitsoft/slack/api/BukkitPoster.java
+++ b/src/main/java/org/circuitsoft/slack/api/BukkitPoster.java
@@ -19,6 +19,22 @@ public class BukkitPoster extends BukkitRunnable {
     private final String message;
     private final String webhookUrl = getWebhookUrl();
     private final String iconUrl;
+    private final Boolean isAction;
+
+    /**
+     * Prepares the message to send to Slack.
+     *
+     * @param message The message to send to Slack.
+     * @param name    The username of the message to send to Slack.
+     * @param iconUrl The image URL of the user that sends the message to Slack. Make this null if the username is a Minecraft player name.
+     * @param isAction  The message is an action or not.
+     */
+    public BukkitPoster(String message, String name, String iconUrl, Boolean isAction) {
+        this.name = name;
+        this.message = message;
+        this.iconUrl = iconUrl;
+        this.isAction = isAction;
+    }
 
     /**
      * Prepares the message to send to Slack.
@@ -28,15 +44,20 @@ public class BukkitPoster extends BukkitRunnable {
      * @param iconUrl The image URL of the user that sends the message to Slack. Make this null if the username is a Minecraft player name.
      */
     public BukkitPoster(String message, String name, String iconUrl) {
-        this.name = name;
-        this.message = message;
-        this.iconUrl = iconUrl;
+         this(message, name, iconUrl, false);
     }
 
     @Override
     public void run() {
         JSONObject json = new JSONObject();
-        json.put("text", name + ": " + message);
+        if (isAction) {
+          json.put("text", "_" + message + "_");
+        } else if (message.startsWith("/")) {
+        	json.put("text", "```" + message + "```");
+        } else {
+        	json.put("text", message);
+        	json.put("mrkdwn", false);
+        }
         json.put("username", name);
         if (iconUrl == null) {
             json.put("icon_url", "https://cravatar.eu/helmhead/" + name + "/100.png");

--- a/src/main/java/org/circuitsoft/slack/bukkit/SlackBukkit.java
+++ b/src/main/java/org/circuitsoft/slack/bukkit/SlackBukkit.java
@@ -43,37 +43,49 @@ public class SlackBukkit extends JavaPlugin implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onChat(AsyncPlayerChatEvent event) {
         if (isVisible("slack.hide.chat", event.getPlayer())) {
-            send('"' + event.getMessage() + '"', event.getPlayer().getName());
+            send(event.getMessage(), event.getPlayer().getName());
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onLogin(PlayerJoinEvent event) {
         if (isVisible("slack.hide.login", event.getPlayer().getUniqueId())) {
-            send("logged in", event.getPlayer().getName());
+            send("logged in", event.getPlayer().getName(), true);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onQuit(PlayerQuitEvent event) {
         if (isVisible("slack.hide.logout", event.getPlayer())) {
-            send("logged out", event.getPlayer().getName());
+            send("logged out", event.getPlayer().getName(), true);
         }
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onCommand(PlayerCommandPreprocessEvent event) {
-        if (isAllowed(event.getMessage()) && isVisible("slack.hide.command", event.getPlayer()) && !event.getMessage().contains("/slack send")) {
+        if (!getConfig().getBoolean("send-commands")) {
+        	return;
+        }
+        String command = event.getMessage().split(" ")[0];
+        if (isAllowed(command) && isVisible("slack.hide.command", event.getPlayer()) && !event.getMessage().contains("/slack send")) {
             send(event.getMessage(), event.getPlayer().getName());
         }
     }
 
     public void send(String message, String name) {
-        new SlackBukkitPoster(this, message, name, null).runTaskAsynchronously(this);
+        send(message, name, null, false);
     }
 
     public void send(String message, String name, String iconUrl) {
-        new SlackBukkitPoster(this, message, name, iconUrl).runTaskAsynchronously(this);
+        send(message, name, iconUrl, false);
+    }
+
+    public void send(String message, String name, Boolean isAction) {
+        send(message, name, null, isAction);
+    }
+
+    public void send(String message, String name, String iconUrl, Boolean isAction) {
+        new SlackBukkitPoster(this, message, name, iconUrl, isAction).runTaskAsynchronously(this);
     }
 
     private boolean isAllowed(String command) {
@@ -156,7 +168,7 @@ public class SlackBukkit extends JavaPlugin implements Listener {
                 sender.sendMessage(ChatColor.DARK_RED + "You are not allowed to execute this command!");
             }
         } else {
-            sender.sendMessage(ChatColor.GOLD + "/slack send <username> <image URL or null for username's skin> <message> - send a custom message to slack \n/slack reload - reload Slack's config");
+            sender.sendMessage(ChatColor.GOLD + "/slack send <username> <image URL or null for username's skin> <message> - send a custom message to slack\n/slack reload - reload Slack's config");
         }
         return true;
     }

--- a/src/main/java/org/circuitsoft/slack/bukkit/SlackBukkitPoster.java
+++ b/src/main/java/org/circuitsoft/slack/bukkit/SlackBukkitPoster.java
@@ -21,18 +21,31 @@ public class SlackBukkitPoster extends BukkitRunnable {
     private final String message;
     private final String webhookUrl = getWebhookUrl();
     private final String iconUrl;
+    private final Boolean isAction;
 
     public SlackBukkitPoster(JavaPlugin plugin, String message, String name, String iconUrl) {
+        this(plugin, message, name, iconUrl, false);
+    }
+
+    public SlackBukkitPoster(JavaPlugin plugin, String message, String name, String iconUrl, Boolean isAction) {
         this.plugin = plugin;
         this.name = name;
         this.message = message;
         this.iconUrl = iconUrl;
+        this.isAction = isAction;
     }
 
     @Override
     public void run() {
         JSONObject json = new JSONObject();
-        json.put("text", name + ": " + message);
+        if (isAction) {
+          json.put("text", "_" + message + "_");
+        } else if (message.startsWith("/")) {
+        	json.put("text", "```" + message + "```");
+        } else {
+        	json.put("text", message);
+        	json.put("mrkdwn", false);
+        }
         json.put("username", name);
         if (iconUrl == null) {
             json.put("icon_url", "https://cravatar.eu/helmhead/" + name + "/100.png");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,10 +1,12 @@
 #The version. Do not touch this.
-version: 1.4.4
+version: 1.5.0
 #The incoming webhook URL you got from Slack.
 webhook: https://hooks.slack.com/services/
 #Show HTTP response codes in console
 debug: false
-#Causes a bit of lag but you can hvae certain players not post to Slack
+#Send player commands to Slack
+send-commands: false
+#Causes a bit of lag but you can have certain players not post to Slack
 use-perms: false
 #Causes lag but you can block commands from being shown to Slack
 use-blacklist: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: Slack
-version: 1.4.4
+version: 1.5.0
 description: Link your server to Slack!
 author: CircuitSoft
-authors: [Janmm14, LaxWasHere, it3d]
+authors: [Janmm14, LaxWasHere, it3d, Davy]
 website: https://circuitsoft.us
 
 main: org.circuitsoft.slack.bukkit.SlackBukkit


### PR DESCRIPTION
Only matching the command not whole message;
Commands now sending to Slack with quote '```';
Actions (e.g. login, logout) now sending to Slack with italic;
Normal messages now sending to Slack without mrkdwn parsing.

!!! Notice that I changed the version to 1.5.0. If you don't want it upgrade, please don't use auto merge on GitHub.